### PR TITLE
update priority

### DIFF
--- a/src/main/java/pers/yufiria/damagedisplay/listener/DamageListener.java
+++ b/src/main/java/pers/yufiria/damagedisplay/listener/DamageListener.java
@@ -10,6 +10,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.potion.PotionEffectType;
@@ -32,7 +33,7 @@ public class DamageListener implements Listener {
 
     private DamageListener() {}
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         if (!(event.getDamageSource().getCausingEntity() instanceof Player player))
             return;


### PR DESCRIPTION
一些伤害机制插件会通过监听实体伤害事件来修改伤害数值，此时伤害数显插件的监听器应该被调整到最后执行，才能保证能够正常显示其他插件修改后的数值。